### PR TITLE
Add a configuration for the chart-testing linter

### DIFF
--- a/.chart-testing.yaml
+++ b/.chart-testing.yaml
@@ -1,0 +1,4 @@
+remote: origin
+target-branch: main
+chart-dirs:
+  - charts

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -26,17 +26,19 @@ jobs:
       - name: Run chart-testing (list-changed)
         id: list-changed
         run: |
-          changed=$(ct list-changed)
+          changed=$(ct list-changed --config .chart-testing.yaml)
           if [[ -n "$changed" ]]; then
             echo "::set-output name=changed::true"
           fi
 
       - name: Run chart-testing (lint)
-        run: ct lint
+        # TODO remove the --chart-dirs option
+        # added as a workaround for https://github.com/helm/chart-testing/issues/364
+        run: ct lint --config .chart-testing.yaml --chart-dirs charts/
 
       - name: Create kind cluster
         uses: helm/kind-action@v1.2.0
         if: steps.list-changed.outputs.changed == 'true'
 
       - name: Run chart-testing (install)
-        run: ct install
+        run: ct install --config .chart-testing.yaml


### PR DESCRIPTION
The chart-testing linter (`ct`) is not working at the moment.

This adds a configuration to make it work.
