### PR TITLE
Remove chart-dirs override

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -32,9 +32,7 @@ jobs:
           fi
 
       - name: Run chart-testing (lint)
-        # TODO remove the --chart-dirs option
-        # added as a workaround for https://github.com/helm/chart-testing/issues/364
-        run: ct lint --config .chart-testing.yaml --chart-dirs charts/
+        run: ct lint --config .chart-testing.yaml
 
       - name: Create kind cluster
         uses: helm/kind-action@v1.2.0


### PR DESCRIPTION
This was a workaround for a problem that doesn't reproduce in ct v3.4.0

Fixes #12 