### PR TITLE
Simplify the lint and release workflows

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -32,13 +32,4 @@ jobs:
           fi
 
       - name: Run chart-testing (lint)
-        # TODO remove the --chart-dirs option
-        # added as a workaround for https://github.com/helm/chart-testing/issues/364
-        run: ct lint --config .chart-testing.yaml --chart-dirs charts/
-
-      - name: Create kind cluster
-        uses: helm/kind-action@v1.2.0
-        if: steps.list-changed.outputs.changed == 'true'
-
-      - name: Run chart-testing (install)
-        run: ct install --config .chart-testing.yaml
+        run: ct lint --config .chart-testing.yaml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,8 +2,8 @@ name: Release Charts
 
 on:
   push:
-    branches:
-      - main
+    tags:
+      - "v*"
 
 jobs:
   release:


### PR DESCRIPTION
The current content of the pipelines Chart does not install on vanilla Kubernetes - mostly due to the use of OpenShift `Route`s.

Therefore, this disables the `install` test for the time being, until this dependency is lifted and/or we have an effective way of testing it on OpenShift.

Also changing the release action to only trigger on new version tags (`v*`) instead of any push.