### PR TITLE
Use the meteor-pipelines service account

### DIFF
--- a/charts/meteor-pipelines/Chart.yaml
+++ b/charts/meteor-pipelines/Chart.yaml
@@ -5,7 +5,7 @@ icon: https://avatars.githubusercontent.com/u/33906690?v=4
 
 type: application
 
-version: 0.2.2
+version: 0.2.3
 appVersion: "1.0.0"
 
 sources:

--- a/charts/meteor-pipelines/templates/eventlistener.yaml
+++ b/charts/meteor-pipelines/templates/eventlistener.yaml
@@ -6,7 +6,7 @@ metadata:
   name: aicoe-ci-listener
   labels: {{- include "meteor-pipelines.labels" . | nindent 4 }}
 spec:
-  serviceAccountName: aicoe-ci-webhook
+  serviceAccountName: meteor-pipelines
   triggers:
     - name: github-pull-request-model
       interceptors:

--- a/charts/meteor-pipelines/templates/rbac.yaml
+++ b/charts/meteor-pipelines/templates/rbac.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: meteor-edit
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: edit
+subjects:
+- kind: ServiceAccount
+  name: meteor-pipelines


### PR DESCRIPTION
Grant edit access to the meteor-pipelines service account and use it for the event listener.

Currently, the installation of the chart fails to complete successfully because a `aicoe-ci-webhook` ServiceAccount does not exist:

```
0s          Warning   FailedCreate        replicaset/el-aicoe-ci-listener-78f5d75466   Error creating: pods "el-aicoe-ci-listener-78f5d75466-" is forbidden: error looking up service account meteor-pipelines-pktjb4zd7e/aicoe-ci-webhook: serviceaccount "aicoe-ci-webhook" not found
```