### PR TITLE
Only install podman and oc when chart testing is needed

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,19 +16,6 @@ jobs:
         with:
           version: v3.4.0
 
-      - name: Set up podman
-        run: |
-          source /etc/os-release
-          echo "deb https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_${VERSION_ID}/ /" | sudo tee /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list
-          curl -L https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_${VERSION_ID}/Release.key | sudo apt-key add -
-          sudo apt-get update
-          sudo apt-get -y install podman
-
-      - name: Set up oc client
-        run: |
-          wget https://mirror.openshift.com/pub/openshift-v4/clients/oc/latest/linux/oc.tar.gz
-          sudo tar xzvf oc.tar.gz -C /usr/local/bin
-
       - name: Set up chart-testing
         uses: helm/chart-testing-action@v2.1.0
 
@@ -42,6 +29,21 @@ jobs:
 
       - name: Run chart-testing (lint)
         run: ct lint --config .chart-testing.yaml
+
+      - name: Set up podman
+        if: steps.list-changed.outputs.changed == 'true'
+        run: |
+          source /etc/os-release
+          echo "deb https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_${VERSION_ID}/ /" | sudo tee /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list
+          curl -L https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_${VERSION_ID}/Release.key | sudo apt-key add -
+          sudo apt-get update
+          sudo apt-get -y install podman
+
+      - name: Set up oc client
+        if: steps.list-changed.outputs.changed == 'true'
+        run: |
+          wget https://mirror.openshift.com/pub/openshift-v4/clients/oc/latest/linux/oc.tar.gz
+          sudo tar xzvf oc.tar.gz -C /usr/local/bin
 
       - name: Run a microshift cluster
         if: steps.list-changed.outputs.changed == 'true'

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-charts/meteor-pipelines/meteor-pipelines-*.tgz
+var/
 deployment-values.yaml

--- a/e2e-test.sh
+++ b/e2e-test.sh
@@ -2,7 +2,7 @@
 
 # TEST-ENV: bring up a cluster
 sudo podman run -d --rm --name microshift --privileged \
-     -v microshift-data:/var/lib -p 6443:6443 \
+     -v microshift-data:/var/lib -p 6443:6443 -p 80:80 -p 443:443 \
      quay.io/microshift/microshift-aio:latest
 sudo podman exec microshift bash -c \
      'while ! test -f "/var/lib/microshift/resources/kubeadmin/kubeconfig"; do


### PR DESCRIPTION
General check for changes and linting don't need `podman` or `oc`, so make them conditional.

Also a couple of minor changes to `.gitignore` (replace unused tgz ref with a useful local dir) and `e2e-test.sh` (expose the cluster router)