### PR TITLE
Add missing manifests for event listener Route and template triggers

### DIFF
--- a/charts/meteor-pipelines/Chart.yaml
+++ b/charts/meteor-pipelines/Chart.yaml
@@ -5,7 +5,7 @@ icon: https://avatars.githubusercontent.com/u/33906690?v=4
 
 type: application
 
-version: 0.2.5
+version: 0.2.6
 appVersion: "1.0.0"
 
 sources:

--- a/charts/meteor-pipelines/templates/el-route.yaml
+++ b/charts/meteor-pipelines/templates/el-route.yaml
@@ -1,0 +1,12 @@
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: el-aicoe-ci-listener
+spec:
+  port:
+    targetPort: http-listener
+  to:
+    kind: Service
+    name: el-aicoe-ci-listener
+    weight: 100
+  wildcardPolicy: None

--- a/charts/meteor-pipelines/templates/eventlistener.yaml
+++ b/charts/meteor-pipelines/templates/eventlistener.yaml
@@ -110,4 +110,4 @@ spec:
         - kind: TriggerBinding
           ref: github-tag
       template:
-        ref: git-tag
+        ref: git-tag-template

--- a/charts/meteor-pipelines/templates/git-pr-template.yaml
+++ b/charts/meteor-pipelines/templates/git-pr-template.yaml
@@ -1,0 +1,91 @@
+apiVersion: triggers.tekton.dev/v1alpha1
+kind: TriggerTemplate
+metadata:
+  name: git-pr-template
+  labels:
+    app: aicoe-ci
+spec:
+  params:
+    - name: pr_number
+      description: Pull request ID.
+    - name: pr_repo
+      description: The git repository pr was raised to.
+    - name: repo_full_name
+      description: The git repository full name.
+    - name: pr_url
+      description: The pr url.
+    - name: repo_url
+      description: The git repository url.
+    - name: default_branch
+      description: The git repository default branch.
+    - name: event_action
+      description: Action performed on Pull request.
+      default: "DEFAULT"
+    - name: pr_comment
+      description: comment on the pull request.
+      default: "DEFAULT"
+    - name: pr_comment_author
+      description: author of the comment on the pull request.
+      default: "DEFAULT"
+    - name: pr_comment_author_association
+      description: comment author's association.
+      default: "DEFAULT"
+    - name: pipelinerun_name
+      description: pipelinerun associated.
+  resourcetemplates:
+    - apiVersion: tekton.dev/v1beta1
+      kind: PipelineRun
+      metadata:
+        name: aicoe-pipelinerun-$(uid)
+        labels:
+          app: aicoe-ci
+          project: $(tt.params.pr_repo)
+          component: $(tt.params.pr_repo)-pr-$(tt.params.pr_number)
+      spec:
+        serviceAccountName: aicoe-ci
+        pipelineRef:
+          name: pull-request-pipeline
+        params:
+          - name: event_action
+            value: $(tt.params.event_action)
+          - name: pr_number
+            value: $(tt.params.pr_number)
+          - name: pr_repo
+            value: $(tt.params.pr_repo)
+          - name: repo_url
+            value: $(tt.params.repo_url)
+          - name: repo_full_name
+            value: $(tt.params.repo_full_name)
+          - name: pr_comment
+            value: $(tt.params.pr_comment)
+          - name: pr_comment_author
+            value: $(tt.params.pr_comment_author)
+          - name: pr_comment_author_association
+            value: $(tt.params.pr_comment_author_association)
+          - name: pipelinerun_name
+            value: aicoe-pipelinerun-$(uid)
+        resources:
+          - name: git-repo
+            resourceSpec:
+              type: git
+              params:
+                - name: revision
+                  value: $(tt.params.default_branch)
+                - name: url
+                  value: $(tt.params.repo_url)
+          - name: s2i-thoth
+            resourceRef:
+              name: thoth-s2i
+          - name: ubi
+            resourceRef:
+              name: ubi8
+          - name: pr-source
+            resourceSpec:
+              type: pullRequest
+              params:
+                - name: url
+                  value: $(tt.params.pr_url)
+              secrets:
+                - fieldName: authToken
+                  secretName: auth-secret
+                  secretKey: token

--- a/charts/meteor-pipelines/templates/git-tag-template.yaml
+++ b/charts/meteor-pipelines/templates/git-tag-template.yaml
@@ -1,0 +1,65 @@
+apiVersion: triggers.tekton.dev/v1alpha1
+kind: TriggerTemplate
+metadata:
+  name: git-tag-template
+  labels:
+    app: aicoe-ci
+spec:
+  params:
+    - name: git_ref
+      description: Git reference value.
+    - name: git_ref_type
+      description: Type of ref Tag or Branch.
+    - name: repo_name
+      description: The git repository title.
+    - name: repo_url
+      description: The git repository url.
+    - name: default_branch
+      description: The git repository default branch.
+    - name: pipelinerun_name
+      description: pipelinerun associated.
+
+  resourcetemplates:
+    - apiVersion: tekton.dev/v1beta1
+      kind: PipelineRun
+      metadata:
+        name: tag-release-$(uid)
+        labels:
+          app: aicoe-ci
+          project: $(tt.params.repo_name)
+          component: tag-$(tt.params.repo_name)
+      spec:
+        serviceAccountName: aicoe-ci
+        timeout: "2h"
+        pipelineRef:
+          name: tag-release-pipeline
+        params:
+          - name: git_ref
+            value: $(tt.params.git_ref)
+          - name: git_ref_type
+            value: $(tt.params.git_ref_type)
+          - name: repo_name
+            value: $(tt.params.repo_name)
+          - name: repo_url
+            value: $(tt.params.repo_url)
+          - name: default_branch
+            value: $(tt.params.default_branch)
+          - name: uid
+            value: $(uid)
+          - name: pipelinerun_name
+            value: tag-release-$(uid)
+        resources:
+          - name: git-repo
+            resourceSpec:
+              type: git
+              params:
+                - name: revision
+                  value: $(tt.params.default_branch)
+                - name: url
+                  value: $(tt.params.repo_url)
+          - name: s2i-thoth
+            resourceRef:
+              name: thoth-s2i
+          - name: ubi
+            resourceRef:
+              name: ubi8


### PR DESCRIPTION
A route for the event listener was missing.

Two template triggers (PRs and tags) were also missing.

Copying these over from aicoe-ci.