### PR TITLE
enabling tls-verify

### DIFF
--- a/charts/meteor-pipelines/Chart.yaml
+++ b/charts/meteor-pipelines/Chart.yaml
@@ -5,7 +5,7 @@ icon: https://avatars.githubusercontent.com/u/33906690?v=4
 
 type: application
 
-version: 0.2.6
+version: 0.2.7
 appVersion: "1.0.0"
 
 sources:

--- a/charts/meteor-pipelines/templates/gather-deployment-metrics-pipeline.yaml
+++ b/charts/meteor-pipelines/templates/gather-deployment-metrics-pipeline.yaml
@@ -27,6 +27,10 @@ spec:
     - name: pr-source
       type: pullRequest
 
+  workspaces:
+    - name: sslcertdir
+      optional: true
+
   tasks:
     - name: gather-metrics-check-inputs
       taskRef:
@@ -67,6 +71,9 @@ spec:
     - name: pr-build-release-run
       taskRef:
         name: pr-build-release
+      workspaces:
+        - name: sslcertdir
+          workspace: sslcertdir
       params:
         - name: pr_number
           value: $(params.pr_number)

--- a/charts/meteor-pipelines/templates/git-issue-template.yaml
+++ b/charts/meteor-pipelines/templates/git-issue-template.yaml
@@ -46,6 +46,14 @@ spec:
         serviceAccountName: pipeline
         pipelineRef:
           name: issue-pipeline
+        workspaces:
+        - name: sslcertdir
+          configMap:
+            name: openshift-service-ca.crt
+            defaultMode: 420
+            items:
+            - key: service-ca.crt
+              path: ca.crt
         params:
           - name: event_action
             value: $(tt.params.event_action)

--- a/charts/meteor-pipelines/templates/git-model-template.yaml
+++ b/charts/meteor-pipelines/templates/git-model-template.yaml
@@ -32,6 +32,14 @@ spec:
         serviceAccountName: pipeline
         pipelineRef:
           name: "gather-deployment-metrics-pipeline"
+        workspaces:
+        - name: sslcertdir
+          configMap:
+            name: openshift-service-ca.crt
+            defaultMode: 420
+            items:
+            - key: service-ca.crt
+              path: ca.crt
         params:
           - name: event_action
             value: $(tt.params.event_action)

--- a/charts/meteor-pipelines/templates/issue-pipeline.yaml
+++ b/charts/meteor-pipelines/templates/issue-pipeline.yaml
@@ -39,6 +39,10 @@ spec:
     - name: ubi
       type: image
 
+  workspaces:
+  - name: sslcertdir
+    optional: true
+
   tasks:
     - name: configuration
       taskRef:
@@ -53,6 +57,9 @@ spec:
     - name: issue-release-run
       taskRef:
         name: issue-release
+      workspaces:
+        - name: sslcertdir
+          workspace: sslcertdir
       conditions:
         - conditionRef: issue-check
           params:
@@ -163,6 +170,9 @@ spec:
     - name: issue-pypi-release-run
       taskRef:
         name: issue-pypi-release
+      workspaces:
+        - name: sslcertdir
+          workspace: sslcertdir
       conditions:
         - conditionRef: issue-check
           params:
@@ -213,6 +223,9 @@ spec:
     - name: issue-pulp-release-run
       taskRef:
         name: issue-pulp-pypi-release
+      workspaces:
+        - name: sslcertdir
+          workspace: sslcertdir
       conditions:
         - conditionRef: issue-check
           params:

--- a/charts/meteor-pipelines/templates/issue-pulp-pypi-release-task.yaml
+++ b/charts/meteor-pipelines/templates/issue-pulp-pypi-release-task.yaml
@@ -83,7 +83,8 @@ spec:
               name: pulp-pypi-secret
               key: password
       script: |
-        twine upload dist/* --repository-url="http://pulp-test-thoth-pulp-experiments.apps.zero.massopen.cloud/pypi/$(params.pulp-index)/simple/"
+        [[ "$(workspaces.sslcertdir.bound)" == "true" ]] && CERT_DIR_FLAG="--cert $(workspaces.sslcertdir.path)"
+        twine upload dist/* --repository-url="http://pulp-test-thoth-pulp-experiments.apps.zero.massopen.cloud/pypi/$(params.pulp-index)/simple/" ${CERT_DIR_FLAG}
 
     - name: comment-on-issue
       env:
@@ -142,3 +143,8 @@ spec:
                     "User-Agent": "aicoe-ci",
                     "Authorization": "Bearer " + os.environ["GITHUBTOKEN"],
                 })
+
+  workspaces:
+  - name: sslcertdir
+    optional: true
+    mountPath: /workspace/sslcertdir

--- a/charts/meteor-pipelines/templates/issue-pypi-release-task.yaml
+++ b/charts/meteor-pipelines/templates/issue-pypi-release-task.yaml
@@ -72,7 +72,8 @@ spec:
               name: pypi-secret
               key: password
       script: |
-        twine upload dist/*
+        [[ "$(workspaces.sslcertdir.bound)" == "true" ]] && CERT_DIR_FLAG="--cert $(workspaces.sslcertdir.path)"
+        twine upload dist/* ${CERT_DIR_FLAG}
 
     - name: comment-on-issue
       env:
@@ -131,3 +132,7 @@ spec:
                     "User-Agent": "aicoe-ci",
                     "Authorization": "Bearer " + os.environ["GITHUBTOKEN"],
                 })
+  workspaces:
+  - name: sslcertdir
+    optional: true
+    mountPath: /workspace/sslcertdir

--- a/charts/meteor-pipelines/templates/issue-release-task.yaml
+++ b/charts/meteor-pipelines/templates/issue-release-task.yaml
@@ -9,7 +9,7 @@ spec:
       default: .
       description: The location of the path to run s2i from.
     - name: TLSVERIFY
-      default: "false"
+      default: "true"
       description:
         Verify the TLS on the registry endpoint (for push/pull to a non-TLS
         registry)
@@ -207,7 +207,9 @@ spec:
       securityContext:
         privileged: true
       script: |
+        [[ "$(workspaces.sslcertdir.bound)" == "true" ]] && CERT_DIR_FLAG="--cert-dir $(workspaces.sslcertdir.path)"
         buildah bud \
+        ${CERT_DIR_FLAG} \
         --storage-driver=overlay \
         --tls-verify=$(params.TLSVERIFY) \
         --layers \
@@ -225,6 +227,7 @@ spec:
     - name: push
       image: quay.io/buildah/stable
       script: |
+        [[ "$(workspaces.sslcertdir.bound)" == "true" ]] && CERT_DIR_FLAG="--cert-dir $(workspaces.sslcertdir.path)"
         set +x
         TAG=$(echo "$(params.issue_body)" | awk -F ':' '{print $2}')
         set -x
@@ -234,6 +237,7 @@ spec:
           registry_repo=$(params.registry_project)
         fi
         buildah push \
+        ${CERT_DIR_FLAG} \
         --authfile=/pushsecret/.dockerconfigjson \
         --tls-verify=$(params.TLSVERIFY) \
         $(params.repo_name)-$(params.issue_number) \
@@ -307,3 +311,8 @@ spec:
     - name: quay-creds
       secret:
         secretName: $(params.registry_secret)
+
+  workspaces:
+  - name: sslcertdir
+    optional: true
+    mountPath: /workspace/sslcertdir

--- a/charts/meteor-pipelines/templates/meteor_buildah.yaml
+++ b/charts/meteor-pipelines/templates/meteor_buildah.yaml
@@ -61,9 +61,10 @@ spec:
     - name: BASE_IMAGE
 
   workspaces:
-    - name: data
-    - name: sslcertdir
-      optional: true
+  - name: data
+  - name: sslcertdir
+    optional: true
+    mountPath: /workspace/sslcertdir
   results:
     - name: IMAGE_DIGEST
       description: Digest of the image just built.
@@ -280,3 +281,8 @@ spec:
   volumes:
     - name: varlibcontainers
       emptyDir: {}
+
+  workspaces:
+  - name: sslcertdir
+    optional: true
+    mountPath: /workspace/sslcertdir

--- a/charts/meteor-pipelines/templates/overlay-build-task.yaml
+++ b/charts/meteor-pipelines/templates/overlay-build-task.yaml
@@ -48,7 +48,7 @@ spec:
       default: .
       description: The location of the path to run s2i from.
     - name: TLSVERIFY
-      default: "false"
+      default: "true"
       description:
         Verify the TLS on the registry endpoint (for push/pull to a non-TLS
         registry)
@@ -191,7 +191,9 @@ spec:
           memory: "2Gi"
           cpu: "2"
       script: |
+        [[ "$(workspaces.sslcertdir.bound)" == "true" ]] && CERT_DIR_FLAG="--cert-dir $(workspaces.sslcertdir.path)"
         buildah bud \
+        ${CERT_DIR_FLAG} \
         --storage-driver=overlay \
         --tls-verify=$(params.TLSVERIFY) \
         --layers \
@@ -209,12 +211,14 @@ spec:
     - name: push
       image: quay.io/buildah/stable
       script: |
+        [[ "$(workspaces.sslcertdir.bound)" == "true" ]] && CERT_DIR_FLAG="--cert-dir $(workspaces.sslcertdir.path)"
         if [ -z "$(params.registry_project)" ]; then
           registry_repo=$(params.repo_name)
         else
           registry_repo=$(params.registry_project)
         fi
         buildah push \
+        ${CERT_DIR_FLAG} \
         --authfile=/pushsecret/.dockerconfigjson \
         --tls-verify=$(params.TLSVERIFY) \
         $(params.repo_name)-$(params.git_ref) \
@@ -260,3 +264,8 @@ spec:
     - name: quay-creds
       secret:
         secretName: $(params.registry_secret)
+
+  workspaces:
+  - name: sslcertdir
+    optional: true
+    mountPath: /workspace/sslcertdir

--- a/charts/meteor-pipelines/templates/overlays-pipeline.yaml
+++ b/charts/meteor-pipelines/templates/overlays-pipeline.yaml
@@ -46,6 +46,14 @@ spec:
           serviceAccountName: pipeline
           pipelineRef:
             name: overlays-release-pipeline
+          workspaces:
+          - name: sslcertdir
+            configMap:
+              name: openshift-service-ca.crt
+              defaultMode: 420
+              items:
+              - key: service-ca.crt
+                path: ca.crt
           params:
             - name: git_ref
               value: $(params.git_ref)

--- a/charts/meteor-pipelines/templates/overlays-release-pipeline.yaml
+++ b/charts/meteor-pipelines/templates/overlays-release-pipeline.yaml
@@ -53,10 +53,17 @@ spec:
     - name: s2i-thoth
       type: image
 
+  workspaces:
+    - name: sslcertdir
+      optional: true
+
   tasks:
     - name: overlay-release-run
       taskRef:
         name: overlay-build
+      workspaces:
+        - name: sslcertdir
+          workspace: sslcertdir
       params:
         - name: git_ref
           value: $(params.git_ref)

--- a/charts/meteor-pipelines/templates/pr-build-release.yaml
+++ b/charts/meteor-pipelines/templates/pr-build-release.yaml
@@ -45,7 +45,7 @@ spec:
       default: .
       description: The location of the path to run s2i from.
     - name: TLSVERIFY
-      default: "false"
+      default: "true"
       description:
         Verify the TLS on the registry endpoint (for push/pull to a non-TLS
         registry)
@@ -203,7 +203,9 @@ spec:
           memory: "2Gi"
           cpu: "2"
       script: |
+        [[ "$(workspaces.sslcertdir.bound)" == "true" ]] && CERT_DIR_FLAG="--cert-dir $(workspaces.sslcertdir.path)"
         buildah bud \
+        ${CERT_DIR_FLAG} \
         --storage-driver=overlay \
         --tls-verify=$(params.TLSVERIFY) \
         --layers \
@@ -221,12 +223,14 @@ spec:
     - name: push
       image: quay.io/buildah/stable
       script: |
+        [[ "$(workspaces.sslcertdir.bound)" == "true" ]] && CERT_DIR_FLAG="--cert-dir $(workspaces.sslcertdir.path)"
         if [ -z "$(params.registry_project)" ]; then
           registry_repo=$(params.pr_repo)
         else
           registry_repo=$(params.registry_project)
         fi
         buildah push \
+        ${CERT_DIR_FLAG} \
         --authfile=/pushsecret/.dockerconfigjson \
         --tls-verify=$(params.TLSVERIFY) \
         $(params.pr_repo)-$(params.pr_number) \
@@ -251,3 +255,8 @@ spec:
     - name: quay-creds
       secret:
         secretName: $(params.registry_secret)
+
+  workspaces:
+  - name: sslcertdir
+    optional: true
+    mountPath: /workspace/sslcertdir

--- a/charts/meteor-pipelines/templates/pr-build.yaml
+++ b/charts/meteor-pipelines/templates/pr-build.yaml
@@ -29,7 +29,7 @@ spec:
       default: .
       description: The location of the path to run s2i from.
     - name: TLSVERIFY
-      default: "false"
+      default: "true"
       description:
         Verify the TLS on the registry endpoint (for push/pull to a non-TLS
         registry)

--- a/charts/meteor-pipelines/templates/pull-request-pipeline.yaml
+++ b/charts/meteor-pipelines/templates/pull-request-pipeline.yaml
@@ -35,6 +35,10 @@ spec:
     - name: pr-source
       type: pullRequest
 
+  workspaces:
+    - name: sslcertdir
+      optional: true
+
   tasks:
     - name: init-task-run
       taskRef:
@@ -349,6 +353,9 @@ spec:
     - name: pr-build-release-run
       taskRef:
         name: pr-build-release
+      workspaces:
+        - name: sslcertdir
+          workspace: sslcertdir
       conditions:
         - conditionRef: action-check
           params:

--- a/charts/meteor-pipelines/templates/tag-build.yaml
+++ b/charts/meteor-pipelines/templates/tag-build.yaml
@@ -6,7 +6,7 @@ spec:
   params:
     # buildah params
     - name: TLSVERIFY
-      default: "false"
+      default: "true"
       description:
         Verify the TLS on the registry endpoint (for push/pull to a non-TLS
         registry)
@@ -77,7 +77,9 @@ spec:
       securityContext:
         privileged: true
       script: |
+        [[ "$(workspaces.sslcertdir.bound)" == "true" ]] && CERT_DIR_FLAG="--cert-dir $(workspaces.sslcertdir.path)"
         buildah bud \
+        ${CERT_DIR_FLAG} \
         --tls-verify=$(params.TLSVERIFY) \
         --storage-driver=overlay \
         --layers \
@@ -93,7 +95,9 @@ spec:
     - name: push
       image: quay.io/buildah/stable
       script: |
+        [[ "$(workspaces.sslcertdir.bound)" == "true" ]] && CERT_DIR_FLAG="--cert-dir $(workspaces.sslcertdir.path)"
         buildah push \
+        ${CERT_DIR_FLAG} \
         --authfile=/pushsecret/.dockerconfigjson \
         --tls-verify=$(params.TLSVERIFY) \
         $(params.repo_name)-$(params.git_ref) \
@@ -115,3 +119,8 @@ spec:
     - name: quay-creds
       secret:
         secretName: $(params.registry_secret)
+
+  workspaces:
+  - name: sslcertdir
+    optional: true
+    mountPath: /workspace/sslcertdir

--- a/charts/meteor-pipelines/templates/tag-release-pipeline.yaml
+++ b/charts/meteor-pipelines/templates/tag-release-pipeline.yaml
@@ -29,6 +29,10 @@ spec:
     - name: ubi
       type: image
 
+  workspaces:
+    - name: sslcertdir
+      optional: true
+
   tasks:
     - name: configuration
       taskRef:
@@ -149,6 +153,9 @@ spec:
     - name: tag-release-run
       taskRef:
         name: tag-release
+      workspaces:
+        - name: sslcertdir
+          workspace: sslcertdir
       conditions:
         - conditionRef: build-check
           resources:

--- a/charts/meteor-pipelines/templates/tag-release-task.yaml
+++ b/charts/meteor-pipelines/templates/tag-release-task.yaml
@@ -42,7 +42,7 @@ spec:
       default: .
       description: The location of the path to run s2i from.
     - name: TLSVERIFY
-      default: "false"
+      default: "true"
       description:
         Verify the TLS on the registry endpoint (for push/pull to a non-TLS
         registry)
@@ -200,7 +200,9 @@ spec:
           memory: "2Gi"
           cpu: "2"
       script: |
+        [[ "$(workspaces.sslcertdir.bound)" == "true" ]] && CERT_DIR_FLAG="--cert-dir $(workspaces.sslcertdir.path)"
         buildah bud \
+        ${CERT_DIR_FLAG} \
         --storage-driver=overlay \
         --tls-verify=$(params.TLSVERIFY) \
         --layers \
@@ -218,12 +220,14 @@ spec:
     - name: push
       image: quay.io/buildah/stable
       script: |
+        [[ "$(workspaces.sslcertdir.bound)" == "true" ]] && CERT_DIR_FLAG="--cert-dir $(workspaces.sslcertdir.path)"
         if [ -z "$(params.registry_project)" ]; then
           registry_repo=$(params.repo_name)
         else
           registry_repo=$(params.registry_project)
         fi
         buildah push \
+        ${CERT_DIR_FLAG} \
         --authfile=/pushsecret/.dockerconfigjson \
         --tls-verify=$(params.TLSVERIFY) \
         $(params.repo_name)-$(params.git_ref) \
@@ -396,3 +400,8 @@ spec:
     - name: quay-creds
       secret:
         secretName: $(params.registry_secret)
+
+  workspaces:
+  - name: sslcertdir
+    optional: true
+    mountPath: /workspace/sslcertdir

--- a/charts/meteor-pipelines/templates/upload-pulp-pypi.yaml
+++ b/charts/meteor-pipelines/templates/upload-pulp-pypi.yaml
@@ -59,4 +59,10 @@ spec:
               name: pulp-pypi-secret
               key: password
       script: |
-        twine upload dist/* --repository-url="http://pulp-test-thoth-pulp-experiments.apps.zero.massopen.cloud/pypi/$(params.pulp-index)/simple/"
+        [[ "$(workspaces.sslcertdir.bound)" == "true" ]] && CERT_DIR_FLAG="--cert $(workspaces.sslcertdir.path)"
+        twine upload dist/* --repository-url="http://pulp-test-thoth-pulp-experiments.apps.zero.massopen.cloud/pypi/$(params.pulp-index)/simple/" ${CERT_DIR_FLAG}
+
+  workspaces:
+  - name: sslcertdir
+    optional: true
+    mountPath: /workspace/sslcertdir

--- a/charts/meteor-pipelines/templates/upload-pypi.yaml
+++ b/charts/meteor-pipelines/templates/upload-pypi.yaml
@@ -48,4 +48,10 @@ spec:
               name: pypi-secret
               key: password
       script: |
-        twine upload dist/*
+        [[ "$(workspaces.sslcertdir.bound)" == "true" ]] && CERT_DIR_FLAG="--cert-dir $(workspaces.sslcertdir.path)"
+        twine upload dist/* ${CERT_DIR_FLAG}
+
+  workspaces:
+  - name: sslcertdir
+    optional: true
+    mountPath: /workspace/sslcertdir


### PR DESCRIPTION
Addresses #13.

I also included this change for pushing of the python packages, as `twine` allows for the `--cert` command similar to how we pass it to `buildah` with `--cert-dir`.