### PR TITLE
Workaround for flaky CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -92,6 +92,7 @@ jobs:
               kubectl get namespace openshift-pipelines && sleep 5 && break
               sleep 5
           done
+          sleep 10 # FIXME: this is a hack; without it, the configmap below sometimes results empty
           kubectl create configmap config-trusted-cabundle \
               --from-file=ca-bundle.crt=/etc/ssl/certs/ca-certificates.crt \
               --dry-run=client -o yaml | \

--- a/e2e-test.sh
+++ b/e2e-test.sh
@@ -34,6 +34,8 @@ while : ; do
   kubectl get namespace openshift-pipelines && sleep 5 && break
   sleep 5
 done
+sleep 10 # FIXME: this is a hack; without it, the ConfigMap below sometimes results empty
+
 # NOTE: the path is for red hat based OSs
 kubectl create configmap config-trusted-cabundle \
         --from-file=ca-bundle.crt=/etc/pki/tls/certs/ca-bundle.crt \


### PR DESCRIPTION
The CI check is flaky. Currently, it is failing more than succeeding, as seen in https://github.com/thoth-station/helm-charts/pull/34#issuecomment-1070981157

The failure looks like this:

```
Run # workaround the lack of automatic CA cert info from cluster network operator
Error from server (NotFound): namespaces "openshift-pipelines" not found
Error from server (NotFound): namespaces "openshift-pipelines" not found
Error from server (NotFound): namespaces "openshift-pipelines" not found
Error from server (NotFound): namespaces "openshift-pipelines" not found
Error from server (NotFound): namespaces "openshift-pipelines" not found
Error from server (NotFound): namespaces "openshift-pipelines" not found
NAME                  STATUS   AGE
openshift-pipelines   Active   4s
configmap/config-trusted-cabundle configured
error: timed out waiting for the condition on tektonconfigs/config
Error: Process completed with exit code 1.
```

I managed to reproduce that locally, and what I see in my test env is that the `configmap/config-trusted-cabundle` is created but with empty content, which then blocks the deployment of tekton:

```
0s          Warning   FailedMount                    pod/tekton-pipelines-controller-64c6449749-7phdm      MountVolume.SetUp failed for volume "config-trusted-cabundle-volume" : configmap references non-existent config key: ca-bundle.crt
```

This PR is to add a hacky workaround, a `sleep 10` before the creation of the configmap. This fixed the issue in my local test env.

I wish I had a better explanation and solution, but sending that in for now to unblock current PRs.