### PR TITLE
Remove the needs-triage label from the issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,7 +1,7 @@
 ---
 name: Bug report
 about: Create a report to help us improve
-labels: "kind/bug, needs-triage"
+labels: kind/bug
 ---
 ## Bug description
 <!-- A clear and concise description of what the bug is. -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,7 +1,7 @@
 ---
 name: Feature request
 about: Suggest an idea for this project
-labels: "kind/feature, needs-triage"
+labels: kind/feature
 ---
 ## Problem statement
 <!-- Is your feature request related to a problem? Please provide a clear and concise description of what the problem is.


### PR DESCRIPTION
prow manages the `needs-triage` label, so it should not be part of the templates.