### PR TITLE
fix(byon): Use notebook-image label for visibility toggle

### DIFF
--- a/charts/meteor-pipelines/Chart.yaml
+++ b/charts/meteor-pipelines/Chart.yaml
@@ -5,7 +5,7 @@ icon: https://avatars.githubusercontent.com/u/33906690?v=4
 
 type: application
 
-version: 0.2.10
+version: 0.2.11
 appVersion: "1.0.0"
 
 sources:

--- a/charts/meteor-pipelines/templates/byon-import-jupyterhub-image.yaml
+++ b/charts/meteor-pipelines/templates/byon-import-jupyterhub-image.yaml
@@ -51,12 +51,10 @@ spec:
                 opendatahub.io/notebook-image-name: $(params.name)
                 opendatahub.io/notebook-image-phase: Validating
                 opendatahub.io/notebook-image-url: $(params.url)
-                opendatahub.io/notebook-image-visible: 'false'
                 opendatahub.io/notebook-image-origin: Admin
               name: $(context.pipelineRun.name)
               namespace: $(context.pipelineRun.namespace)
               labels:
-                opendatahub.io/notebook-image: 'true'
                 app.kubernetes.io/created-by: byon
             spec:
               lookupPolicy:
@@ -165,7 +163,14 @@ spec:
                 opendatahub.io/notebook-image-message: |
                   $MESSAGES
                 opendatahub.io/notebook-image-phase: "$PHASE"
-                opendatahub.io/notebook-image-visible: "$VISIBLE"
+            EOM
+
+            [ "$VISIBLE" == "true" ] && cat <<EOM >> patch-file.yaml
+              labels:
+                opendatahub.io/notebook-image: 'true'
+            EOM
+
+            cat <<EOM >> patch-file.yaml
             spec:
               tags:
                 - annotations:


### PR DESCRIPTION
According to https://github.com/opendatahub-io/jupyterhub-singleuser-profiles/issues/217 we'll use the `opendatahub.io/notebook-image` label as the Spawner visibility toggle directly so no Spawner changes are needed. Instead we need to adapt our pipelines and dashboard backend.