### PR TITLE
fix(byon): Openshift pipelines for OCP 4.8 doesn't assume default string type (4.9 does)

### DIFF
--- a/charts/meteor-pipelines/Chart.yaml
+++ b/charts/meteor-pipelines/Chart.yaml
@@ -5,7 +5,7 @@ icon: https://avatars.githubusercontent.com/u/33906690?v=4
 
 type: application
 
-version: 0.2.15
+version: 0.2.16
 appVersion: "1.0.0"
 
 sources:

--- a/charts/meteor-pipelines/templates/byon-import-jupyterhub-image.yaml
+++ b/charts/meteor-pipelines/templates/byon-import-jupyterhub-image.yaml
@@ -77,6 +77,7 @@ spec:
       taskSpec:
         params:
           - name: url
+            type: string
         workspaces:
           - name: data
         steps:


### PR DESCRIPTION
Backwards compatibility for OCP 4.8

Same as: https://github.com/operate-first/odh-manifests/pull/21

Signed-off-by: Tomas Coufal <tcoufal@redhat.com>